### PR TITLE
Add link to nunito font in template.ts

### DIFF
--- a/api/_lib/template.ts
+++ b/api/_lib/template.ts
@@ -141,6 +141,10 @@ export function getHtml(parsedReq: ParsedRequest) {
   <meta charset="utf-8">
   <title>Generated Image</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,600;1,700;1,800;1,900&display=swap"
+      rel="stylesheet"
+    />
   <style>
     ${getCss(theme, fontSize)}
   </style>


### PR DESCRIPTION
Forgot to add a link to Nunito within the template.ts file previously and was confused as to why it wasn't working. Fixed now!